### PR TITLE
Update uCentral integration for VyOS cloud management

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,34 @@ At this time you can either load a default configuration and use VyOS in a "stan
 
 ### OpenWifi Cloud SDK mode
 
-### Setup of Ucentral-Client Container
+#### VyOS Minimal Configuration
+
+Before setting up the uCentral client, configure VyOS with minimal settings required for cloud management:
+
+```
+configure
+
+# Enable DHCP on WAN interface (br0)
+set interfaces bridge br0 address dhcp
+
+# Enable HTTPS API service
+set service https
+
+# Enable REST API endpoint (required for uCentral configuration management)
+# The REST endpoint allows the uCentral client to push configurations via API
+set service https api rest
+
+# Set API key (use a secure key in production)
+set service https api keys id ucentral key 'MY-HTTPS-API-PLAINTEXT-KEY'
+
+commit
+save
+exit
+```
+
+**Note on REST API**: The `rest` endpoint is required because uCentral uses the `/config-file` API to push complete configurations in a single transaction. Without REST enabled, the API will reject configuration requests. The API key set here must match the `key` value in `/etc/ucentral/vyos-info.json` inside the ucentral-olg container.
+
+#### Setup of Ucentral-Client Container
 
 - SSH to the OLG Ubuntu host
 - Run `sudo /opt/staging_scripts/ucentral-setup.sh setup` to setup the ucentral-client container

--- a/grub.cfg
+++ b/grub.cfg
@@ -4,7 +4,7 @@ insmod png
 loadfont unicode
 gfxpayload text
 
-ISO_VERSION="v0.0.2"
+ISO_VERSION="v0.0.8"
 
 menuentry "Install Open LAN Gateway (ISO $ISO_VERSION)" {
 	linux	/casper/vmlinuz autoinstall fsck.mode=skip   ds=nocloud\;s=/cdrom/nocloud/ ipv6.disable=1 console=ttyS0,115200n8 console=tty0 network-config=disabled ---

--- a/iso-files/ucentral-setup.sh
+++ b/iso-files/ucentral-setup.sh
@@ -5,7 +5,7 @@ ACTION="$1"
 
 # ================= CONFIG =================
 CONTAINER="ucentral-olg"
-IMAGE="routerarchitect123/ucentral-client:olgV5"
+IMAGE="mjhnetexp/ucentral-client:olgV6-test"
 
 BRIDGE="br-wan"
 

--- a/iso-files/ucentral-setup.sh
+++ b/iso-files/ucentral-setup.sh
@@ -5,7 +5,7 @@ ACTION="$1"
 
 # ================= CONFIG =================
 CONTAINER="ucentral-olg"
-IMAGE="mjhnetexp/ucentral-client:olgV6-test"
+IMAGE="mjhnetexp/ucentral-client:olgV7"
 
 BRIDGE="br-wan"
 


### PR DESCRIPTION
  Description:

  Updates the OLG installer to support VyOS cloud management via uCentral protocol.

  Changes

  iso-files/ucentral-setup.sh:
  - Update container image reference to mjhnetexp/ucentral-client:olgV6-test
  - This image includes VyOS integration from SDK PR #6

  README.md:
  - Add VyOS minimal configuration section for Cloud SDK mode
  - Document HTTPS API and REST endpoint requirements
  - Explain /config-file API usage for configuration management

  Dependencies

  This PR depends on:
  - SDK PR #6: https://github.com/Telecominfraproject/olg-installer/pull/6
  - Schema PR #1: https://github.com/Telecominfraproject/olg-ucentral-schema/pull/1

  The container image must be rebuilt from SDK PR #6 and pushed to production registry before this can be merged.

  Testing

  Validated on MinisForum MS-01 hardware:
  - ✅ VyOS VM installation and minimal configuration
  - ✅ uCentral container setup with volume mounts
  - ✅ Cloud connection established
  - ✅ Configuration push from controller (5-VLAN test)
  - ✅ VyOS configuration successfully applied via REST API
  - ✅ Complete router functionality: interfaces, NAT, DHCP, DNS

  Post-Merge Tasks

  After SDK PR #6 is merged and production image is built:
  - Update IMAGE reference from mjhnetexp/ucentral-client:olgV6-test to production image