### PR TITLE
Add VyOS operational show command support to HTTPS API

### DIFF
--- a/olg-ucentral-client-sdk/feeds/ucentral/ucentral-schema/files/usr/share/ucentral/vyos/https_server_api.uc
+++ b/olg-ucentral-client-sdk/feeds/ucentral/ucentral-schema/files/usr/share/ucentral/vyos/https_server_api.uc
@@ -51,6 +51,16 @@ return{
             payloadObj.path = [];
         }
 
+    } else if (op == "show") {
+        endpoint = "/show";
+
+        if (op_arg && op_arg.path) {
+            payloadObj.path = op_arg.path;
+        } else {
+            // default: empty path
+            payloadObj.path = [];
+        }
+
     } else {
         fprintf(stderr, "Unsupported op: %s\n", op);
         return null;
@@ -63,7 +73,7 @@ return{
     // Build the curl command
     let cmd = sprintf(
         "curl -skL --connect-timeout 3 -m 5 -X POST %s " +
-        "--form-string data=%s --form key=%s",
+        "--form data=%s --form key=%s",
         quoteForShell(url),
         quoteForShell(payloadStr),
         quoteForShell(key)


### PR DESCRIPTION
 Add VyOS Operational Show Command Support to HTTPS API

Overview

  This PR extends the VyOS HTTPS API wrapper to support operational mode commands, which are needed for state collection and monitoring.

  Changes

  Added /show endpoint support to vyos/https_server_api.uc:
  - Enables querying VyOS operational state (uptime, memory, interfaces, DHCP leases, etc.)
  - Fixes form data encoding (--form-string → --form) for proper multipart/form-data submission

  API Endpoints Now Available

  - load/merge (config-file endpoint) - Apply configurations to VyOS
  - showConfig (retrieve endpoint) - Read current VyOS configuration
  - show (show endpoint) - NEW - Query operational state

  Use Case

  This will be used by the upcoming state.uc implementation in olg-ucentral-schema to report gateway status to the cloud (system
  metrics, interface counters, DHCP leases, etc.).

  Testing

  ✅ Tested on VyOS 2025.12.13-0020-rolling with OLG hardware (MinisForum MS-01)
  ✅ Operational commands working (show system uptime, show interfaces, show dhcp server leases)
  ✅ Form encoding fix verified with VyOS API