### PR TITLE
Prepare v0.0.3 release with updated ucentral-client image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 NOTE: the project follows [Semantic Versioning](http://semver.org/).
 
+## v0.0.3 - March 11th, 2026
+
+- Updated ucentral-client Docker image to olgV8
+- Includes updated ucentral-schema from ra_proposal branch (SDK commit 6491570)
+- VyOS integration improvements and schema enhancements
+
 ## v0.0.2 - February 12th, 2026
 
 - Add Ucentral support and documentation

--- a/grub.cfg
+++ b/grub.cfg
@@ -4,7 +4,7 @@ insmod png
 loadfont unicode
 gfxpayload text
 
-ISO_VERSION="v0.0.2"
+ISO_VERSION="v0.0.3"
 
 menuentry "Install Open LAN Gateway (ISO $ISO_VERSION)" {
 	linux	/casper/vmlinuz autoinstall fsck.mode=skip   ds=nocloud\;s=/cdrom/nocloud/ ipv6.disable=1 console=ttyS0,115200n8 console=tty0 network-config=disabled ---

--- a/iso-files/ucentral-setup.sh
+++ b/iso-files/ucentral-setup.sh
@@ -5,7 +5,7 @@ ACTION="$1"
 
 # ================= CONFIG =================
 CONTAINER="ucentral-olg"
-IMAGE="routerarchitect123/ucentral-client:olgV5"
+IMAGE="mjhnetexp/ucentral-client:olgV8"
 
 BRIDGE="br-wan"
 


### PR DESCRIPTION
- Updated iso-files/ucentral-setup.sh to use mjhnetexp/ucentral-client:olgV8
- Updated ISO version to v0.0.3 in grub.cfg
- Added v0.0.3 changelog entry

The olgV8 image contains:
- Updated ucentral-schema from ra_proposal branch (SDK commit 6491570)
- Latest VyOS integration improvements
- Schema enhancements for NAT and operational commands