### PR TITLE
  Add VyOS API support for /configure and /config-file save

### DIFF
--- a/olg-ucentral-client-sdk/feeds/ucentral/ucentral-schema/files/usr/share/ucentral/vyos/https_server_api.uc
+++ b/olg-ucentral-client-sdk/feeds/ucentral/ucentral-schema/files/usr/share/ucentral/vyos/https_server_api.uc
@@ -29,10 +29,12 @@ return{
     let endpoint;
     let payloadObj = { op: op };
 
-    if (op == "load" || op == "merge") {
+    if (op == "load" || op == "merge" || op == "save") {
         endpoint = "/config-file";
 
-        if (op_arg && op_arg.file) {
+        if (op == "save") {
+            // save operation doesn't need file or string
+        } else if (op_arg && op_arg.file) {
             payloadObj.file = op_arg.file;
         } else if (op_arg && op_arg.string) {
             payloadObj.string = op_arg.string;
@@ -59,6 +61,21 @@ return{
         } else {
             // default: empty path
             payloadObj.path = [];
+        }
+
+    } else if (op == "set" || op == "delete") {
+        endpoint = "/configure";
+
+        if (op_arg && op_arg.path) {
+            payloadObj.path = op_arg.path;
+        } else {
+            fprintf(stderr, "Missing path for op %s\n", op);
+            return null;
+        }
+
+        // For 'set', we may have a value
+        if (op == "set" && op_arg.value != null) {
+            payloadObj.value = op_arg.value;
         }
 
     } else {


### PR DESCRIPTION
  ## Summary

  Add support for additional VyOS API operations required for NAT persistence workaround:
  - `/configure` endpoint: `set` and `delete` operations
  - `/config-file` endpoint: `save` operation

  ## Changes in `https_server_api.uc`

  ### 1. Added `save` operation to `/config-file` endpoint (lines 32-44)
  - Allows saving running configuration to `/config/config.boot`
  - No payload needed (just `op: "save"`)
  - Required for persisting NAT rules across VyOS reboots

  ### 2. Added `/configure` endpoint support (lines 66-79)
  - Supports `set` and `delete` operations
  - Requires `path` array parameter
  - `set` operation optionally accepts `value` parameter
  - Auto-commits changes (no explicit commit needed)

  ## Technical Notes

  - `/configure` endpoint only supports `set`/`delete` operations (not `commit`/`save`)
  - Commit happens automatically after each operation
  - Save must use `/config-file` endpoint with `op: "save"`

  ## Use Case

  These operations are required for the NAT persistence workaround where we:
  1. Delete old NAT rules: `/configure delete nat source`
  2. Apply new rules: `/configure set nat source rule X ...`
  3. Save to config.boot: `/config-file save`

  This ensures NAT rules use the correct bridge interface (`br0`) and persist across VyOS reboots.

  ## Related PRs

  This change is required by the companion PR in the `olg-ucentral-schema` repository that implements the NAT persistence fix.

  ## Testing

  Tested on MinisForum MS-01 with VyOS VM:
  - ✅ `/configure set` successfully creates NAT rules
  - ✅ `/configure delete` successfully removes NAT rules
  - ✅ `/config-file save` successfully persists to config.boot
  - ✅ Changes survive VyOS reboots